### PR TITLE
Use .pem file if on windows

### DIFF
--- a/lib/block_io.php
+++ b/lib/block_io.php
@@ -83,6 +83,15 @@ class BlockIo
 
         // Initiate cURL and set headers/options
         $ch  = curl_init();
+        
+        // If we run windows, make sure the needed pem file is used
+        if(strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        	$pemfile = dirname(realpath(__FILE__)) . DIRECTORY_SEPARATOR . 'cacert.pem';
+        	if(!file_exists($pemfile)) {
+        		throw new Exception("Needed .pem file not found. Please download the .pem file at http://curl.haxx.se/ca/cacert.pem and save it as " . $pemfile);
+        	}        	
+        	curl_setopt($ch, CURLOPT_CAINFO, $pemfile);
+        }
 
 	// it's a GET method
 	if ($method == 'GET') { $url .= '&' . $addedData; }


### PR DESCRIPTION
Instruct curl to use the needed .pem file if we are running on windows.
The code checks for the .pem file in the same location as the BlockIo
class file and if it's not found an exception will be thrown with
ionformation about downloading the .pem file and where to palce it.

This gets rid of the need to alter php configuration files in order to
get the library working on windows.