### PR TITLE
deprecated array_key_exists

### DIFF
--- a/lib/block_io.php
+++ b/lib/block_io.php
@@ -128,7 +128,7 @@ class BlockIo
 
 	 $response = $this->_request($name,$args);
 
-	 if ($response->status == 'success' && array_key_exists('reference_id', $response->data))
+	 if ($response->status == 'success' && property_exists($response->data, 'reference_id'))
 	 { // we have signatures to append
 	 
 	   // get our encryption key ready
@@ -189,7 +189,7 @@ class BlockIo
 	 
 	 $response = $this->_request($name,$args);
 
-	 if ($response->status == 'success' && array_key_exists('reference_id', $response->data))
+	 if ($response->status == 'success' && property_exists($response->data, 'reference_id'))
 	 { // we have signatures to append
 
 	   // grab inputs


### PR DESCRIPTION
Because of an deprecated function we are not able to send transaction anymore.
I've changed all occurrences of  array_key_exists  with property_exists.

Tested - it is working ;-)
Tx ID: 103d0cfdfd2358f5772ad0db1de56c6c04240d6345e7d51c4b8c915f738c58ff


php 7.4+  (for sure php7.4.6)